### PR TITLE
Use `include_str!` to return string slices with the static lifetime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,8 @@
-use std::fs::File;
-use std::io::prelude::*;
+pub fn list() -> Vec<&'static str> {
+    let contents = include_str!("words.txt");
 
-pub fn list() -> Vec<String> {
-    let mut file = File::open("./words.txt").unwrap();
-    let mut contents = String::new();
-    file.read_to_string(&mut contents).unwrap();
-
-    let words: Vec<String> = contents
+    let words: Vec<&'static str> = contents
         .split('\n')
-        .map(|x| x.to_string())
         .collect();
 
     words


### PR DESCRIPTION
[`include_str!`](https://doc.rust-lang.org/std/macro.include_str.html?search=) lets us get rid of the `String` allocations and just hand out string slices that live forever, since it's *like* the contents of words.txt are in lib.rs without having them *actually* be in there :)